### PR TITLE
Add help message for "-h" and "--help"

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,12 +8,13 @@ import (
 )
 
 func main() {
+	// override default usage
+	anewUsage(flag.CommandLine)
 	flag.Parse()
 
 	fn := flag.Arg(0)
 	if fn == "" {
-		fmt.Println("usage: anew <file>")
-		os.Exit(1)
+		anewUsage(flag.CommandLine)
 	}
 
 	lines := make(map[string]bool)
@@ -51,4 +52,9 @@ func main() {
 		fmt.Println(line)
 		f.WriteString(line + "\n")
 	}
+}
+
+func anewUsage(f *flag.FlagSet) {
+	fmt.Printf("usage: %s <file>", os.Args[0])
+	os.Exit(1)
 }


### PR DESCRIPTION
anew will only return usage instructions when used with no arguments. This adds support for "-h" and "--help". Everything I tested on my end works as expected, but I was working from https://stackoverflow.com/questions/28091963/golang-flag-library-unable-to-override-usage-function-that-prints-out-command-l and am still wrapping my head around what it's doing so you might want to double-check that I haven't done something stupid :)